### PR TITLE
Fixing logger class for service.

### DIFF
--- a/greeting-config/src/main/java/io/pivotal/quote/QuoteService.java
+++ b/greeting-config/src/main/java/io/pivotal/quote/QuoteService.java
@@ -10,7 +10,7 @@ import org.springframework.web.client.RestTemplate;
 @Service
 @RefreshScope
 public class QuoteService {
-	Logger logger = LoggerFactory.getLogger(QuoteController.class);
+	Logger logger = LoggerFactory.getLogger(QuoteService.class);
 
 	@Value("${quoteServiceURL:}")
 	private String quoteServiceURL;


### PR DESCRIPTION
Noticed during the lab that the log around the quote service URL had the QuoteController and it confused me as there was no log call. Found the call was actually in the QuoteService but the logger in that class was using the QuoteController as the class.